### PR TITLE
Fix unexpected summoner spells

### DIFF
--- a/roleml/roleml.py
+++ b/roleml/roleml.py
@@ -250,8 +250,10 @@ def get_features(match, timeline, cassiopeia_dicts = False):
         # Summoner spells
         participant_features.update(spells)
         if participant[feature_names["spell1Id"]] > 0:
-            participant_features["spell-" + str(participant[feature_names["spell1Id"]])] = 1
-            participant_features["spell-" + str(participant[feature_names["spell2Id"]])] = 1
+            for feature_name in ("spell1Id", "spell2Id"):
+                spell_name = "spell-{}".format(participant[feature_names[feature_name]])
+                if spell_name in spells:
+                    participant_features[spell_name] = 1
 
         # Player stats
         participant_features.update(player_stats[participant_id])


### PR DESCRIPTION
Hey! Looks like I found little bug.

Game to reproduce this case:
| gameId | platformId |
| --- | --- |
|266041574|TR1|

https://github.com/Canisback/roleML/blob/07f711daba308c8bd4f09a06d6c8bbb0dbdb1519/roleml/roleml.py#L252-L254

`"spell-" + str(participant[feature_names["spell(1|2)Id"]])` can take values which are not included in `spells` tuple. In this particular case this values are: `spell-2, spell-13`. As a result `df` contains uninitialized columns with following structure:
```
>> df['spell-2'].values
array([nan, nan, nan, nan,  1., nan, nan, nan, nan, nan]) 
```

Attempt to make a prediction using this `df` fails with following exception:
```
ValueError: Input contains NaN, infinity or a value too large for dtype('float32').
```

This PR fixing this issue by adding additional check whether `spell-{N}` is in `spells` tuple or not.

P.S. Thanks for the lib it's really useful!