### PR TITLE
 Fixes an issue happening when calling max() on an empty lane frequency dict

### DIFF
--- a/roleml/features.py
+++ b/roleml/features.py
@@ -138,12 +138,11 @@ def _get_positions(timeline: dict):
 def _get_most_frequent_lane(participants_positions):
     most_frequent_lane = {}
     for participant_id in participants_positions:
-        lane_frequency = collections.defaultdict(lambda: 0)
+        lane_frequency = {'bot': 0, 'jungle': 0, 'mid': 0, 'top': 0}
 
         for lane in participants_positions[participant_id]:
             if lane is not None:
                 lane_frequency[lane] += 1
-
         most_frequent_lane[participant_id] = max(lane_frequency, key=lane_frequency.get)
 
     return most_frequent_lane

--- a/roleml/roleml.py
+++ b/roleml/roleml.py
@@ -43,7 +43,7 @@ def predict(match, timeline, cassiopeia_dicts=False) -> dict:
     Args:
         match: a MatchDto
         timeline: the associated MatchTimelineDto
-        cassiopeia_dicts: ???
+        cassiopeia_dicts: cassiopeia_dicts: whether or not use cassiopeia feature names
 
     Returns:
         A dictionary mapping participantId to the role defined by _role_format

--- a/roleml/roleml.py
+++ b/roleml/roleml.py
@@ -43,7 +43,7 @@ def predict(match, timeline, cassiopeia_dicts=False) -> dict:
     Args:
         match: a MatchDto
         timeline: the associated MatchTimelineDto
-        cassiopeia_dicts: cassiopeia_dicts: whether or not use cassiopeia feature names
+        cassiopeia_dicts: whether or not use cassiopeia feature names
 
     Returns:
         A dictionary mapping participantId to the role defined by _role_format


### PR DESCRIPTION
By initializing the `lane_frequency` dictionary with the default constructor, it was possible that it would not contain any data if the given player hadn't shown himself on a lane, resulting on a `ValueError: max() arg is an empty sequence` error when `max(lane_frequency, key=lane_frequency.get)` was called.